### PR TITLE
🚸 ui: adjust layout for order button and improve scroll area height

### DIFF
--- a/src/app/(page)/register/page.tsx
+++ b/src/app/(page)/register/page.tsx
@@ -38,7 +38,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Toaster } from "@/components/ui/toaster";
 import { useToast } from "@/hooks/use-toast";
 
-
 interface MenuItem {
     id: string;
     menuName: string;
@@ -249,8 +248,8 @@ export default function Component() {
                 </CardTitle>
             </CardHeader>
             <CardContent className="flex-1 overflow-hidden">
-                <ScrollArea className="h-[calc(100vh-16rem)]">
-                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
+                <ScrollArea className="h-[calc(100vh-20rem)]">
+                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4 pb-20">
                         {menuItems.map((item) => (
                             <Card
                                 key={item.id}
@@ -294,16 +293,6 @@ export default function Component() {
                     </div>
                 </ScrollArea>
             </CardContent>
-            <CardFooter className="border-t p-4">
-                <Button
-                    onClick={() => setShowOrderDialog(true)}
-                    className="w-full"
-                    disabled={cart.length === 0}
-                >
-                    <ShoppingCart className="w-5 h-5 mr-2" />
-                    Proceed to Order ({cart.length})
-                </Button>
-            </CardFooter>
         </Card>
     );
 
@@ -718,6 +707,20 @@ export default function Component() {
                 )}
             </header>
             <main className="flex-1 overflow-hidden p-4">{renderMenu()}</main>
+
+            {/* Fixed order button at bottom */}
+            <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 shadow-lg z-50">
+                <Button
+                    onClick={() => setShowOrderDialog(true)}
+                    className="w-full"
+                    disabled={cart.length === 0}
+                    size="lg"
+                >
+                    <ShoppingCart className="w-5 h-5 mr-2" />
+                    Proceed to Order ({cart.length})
+                </Button>
+            </div>
+
             {renderItemDialog()}
             {renderOrderDialog()}
             {renderCashierDialog()}


### PR DESCRIPTION
This pull request refactors the layout of the `register` page in `src/app/(page)/register/page.tsx` to improve the user interface and usability. The most significant changes include modifying the scrollable area, repositioning the order button to a fixed location, and removing the footer.

### Layout adjustments:

* Adjusted the height of the `ScrollArea` component to `h-[calc(100vh-20rem)]` and added padding to the bottom of the grid container (`pb-20`) to ensure proper spacing for the new fixed order button. (`[src/app/(page)/register/page.tsxL252-R252](diffhunk://#diff-c10f10990642a6f181b84e792693ef2b0d0e02a3450b5911a8636dd4f037e311L252-R252)`)

### Button repositioning:

* Removed the `CardFooter` containing the "Proceed to Order" button and replaced it with a fixed button at the bottom of the viewport. The new button is styled with a white background, shadow, and border, ensuring it remains visible and accessible regardless of scroll position. (`[[1]](diffhunk://#diff-c10f10990642a6f181b84e792693ef2b0d0e02a3450b5911a8636dd4f037e311L297-L306)`, `[[2]](diffhunk://#diff-c10f10990642a6f181b84e792693ef2b0d0e02a3450b5911a8636dd4f037e311R710-R723)`)